### PR TITLE
adde clickoutside to close false when undefined

### DIFF
--- a/src/js/mdColorPicker.js
+++ b/src/js/mdColorPicker.js
@@ -775,7 +775,7 @@ angular.module('mdColorPicker', [])
                     options.hasBackdrop = true;
 
                 if (options.clickOutsideToClose === undefined)
-                    options.clickOutsideToClose = true;
+                    options.clickOutsideToClose = false;
 
                 if (options.defaultValue === undefined)
                     options.defaultValue = '#FFFFFF';


### PR DESCRIPTION
changed if (options.clickOutsideToClose === undefined)
options.clickOutsideToClose = false; html attribute for this one is not working (click-outside-to-close = 'false') . Probably why we thought it wasn't clickoutside to close issue. When we double click and the modal opens we already clicked out side also because the second click happened out side the modal. Hence the behavior open and close when double click.